### PR TITLE
Print help when no arguments are provided.

### DIFF
--- a/uxy
+++ b/uxy
@@ -448,7 +448,10 @@ def main():
   p.set_defaults(func=uxy_cmd_to_yaml)
 
   args = parser.parse_args(sys.argv[1:])
-  args.func(args)
+  if len(vars(args)) == 0:
+    parser.print_help()
+  else:
+    args.func(args)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Providing no arguments currently crashes like this:

$ ./uxy
Traceback (most recent call last):
  File "./uxy", line 454, in <module>
    main()
  File "./uxy", line 451, in main
    args.func(args)
AttributeError: 'Namespace' object has no attribute 'func'

Signed-off-by: Detlev Zundel <dzu@member.fsf.org>