### PR TITLE
Specified Loader class in yaml.load

### DIFF
--- a/uxy
+++ b/uxy
@@ -300,7 +300,7 @@ def uxy_cmd_from_yaml(args):
   s = ""
   for ln in sys.stdin:
     s += ln
-  root = yaml.load(s)
+  root = yaml.load(s, Loader=yaml.FullLoader)
   # Normalize the dict. Collect the field names along the way.
   fields = {}
   if not isinstance(root, list):


### PR DESCRIPTION
Specified Loader class (`yaml.FullLoader`) since calling `yaml.load` without specifying a loader class as per [docs](https://msg.pyyaml.org/load).